### PR TITLE
move recipes to existing category to make GUI looks better

### DIFF
--- a/prototypes/formaldehyde.lua
+++ b/prototypes/formaldehyde.lua
@@ -24,6 +24,7 @@ data:extend({
     type = "recipe",
     name = "formaldehyde",
     category = "chemistry",
+    subgroup = "chemical",
     enabled = "false",
     ingredients = {
       {type="fluid", name="gas", amount=10}

--- a/prototypes/k2-recipe.lua
+++ b/prototypes/k2-recipe.lua
@@ -5,6 +5,7 @@ if mods.Krastorio2 then
       type = "recipe",
       name = "gas-reforming",
       category = "chemistry",
+      subgroup = "chemical",
       main_product = "hydrogen",
       icons = {
         {icon = kr_fluids_icons_path.."hydrogen.png", icon_size = 64, icon_mipmaps = 4},
@@ -24,6 +25,7 @@ if mods.Krastorio2 then
       type = "recipe",
       name = "formaldehyde-methanol",
       category = "chemistry",
+      subgroup = "chemical",
       main_product = "formaldehyde",
       icons = {
         {icon =  "__bzgas__/graphics/icons/formaldehyde.png", icon_size = 128, scale = 0.125},
@@ -47,6 +49,7 @@ if mods.Krastorio2 then
       type = "recipe",
       name = "methane-reforming",
       category = "chemistry",
+      subgroup = "chemical",
       main_product = "hydrogen",
       icons = {
         {icon = kr_fluids_icons_path.."hydrogen.png", icon_size = 64, icon_mipmaps = 4},

--- a/prototypes/se-recipe.lua
+++ b/prototypes/se-recipe.lua
@@ -12,6 +12,7 @@ if util.se6() then
       type = "recipe",
       name = "methane-pre-reforming",
       category = "chemistry",
+      subgroup = "chemical",
       main_product = "se-methane-gas",
       icons = {
         {icon =  "__space-exploration-graphics__/graphics/icons/fluid/methane-gas.png", icon_size = 64},
@@ -30,6 +31,7 @@ if util.se6() then
       type = "recipe",
       name = "formaldehyde-methane",
       category = "chemistry",
+      subgroup = "chemical",
       icons = {
         {icon =  "__bzgas__/graphics/icons/formaldehyde.png", icon_size = 128, scale = 0.125},
         {icon =  "__space-exploration-graphics__/graphics/icons/fluid/methane-gas.png", icon_size = 64, scale = 0.125, shift={-8,-8}},


### PR DESCRIPTION
As I noticed when unlocking all recipes (K2+SE+all BZ), there is one extra category in recipe (see below)
<img width="441" alt="Screenshot 2022-12-25 at 19 25 52" src="https://user-images.githubusercontent.com/27101659/209496730-8913cb0d-6f44-44f4-ba8f-f5c101ed5931.png">
The extra category directly caused one extra column which is so annoying (at least for me), so I simply moved them to the subgroup of "chemical". Now they are located as below:
<img width="437" alt="Screenshot 2022-12-25 at 19 39 37" src="https://user-images.githubusercontent.com/27101659/209496992-f8be3063-1a9b-4ac0-bbb4-6ebeea5fae60.png">

However, I didn't check all recipes for other compatibility files, and there definitely exists some other recipes appear in a separate category. Also, the order may not be what you want, so this is just a temp solution for now.