### PR TITLE
Use light oil overlay from K2 if playing with K2

### DIFF
--- a/prototypes/phenol.lua
+++ b/prototypes/phenol.lua
@@ -73,6 +73,12 @@ if data.raw.item["coke"] then
   else
     util.add_effect("basic-chemistry", {type="unlock-recipe", recipe="phenol"})
   end
+
+  if mods.Krastorio2 then
+    light_oil_icon = { icon = "__Krastorio2Assets__/icons/fluids/light-oil.png", icon_size = 64, icon_mipmaps = 4, scale=0.25, shift={-8,-8}}
+  else
+    light_oil_icon = { icon = "__base__/graphics/icons/fluid/light-oil.png", icon_size = 64, icon_mipmaps = 4, scale=0.25, shift={-8,-8}}
+  end
   data:extend({
     {
       type = "recipe",
@@ -82,7 +88,7 @@ if data.raw.item["coke"] then
       enabled = "false",
       icons = {
         {icon = "__bzgas__/graphics/icons/phenol.png", icon_size = 128},
-        {icon = "__base__/graphics/icons/fluid/light-oil.png", icon_size = 64, icon_mipmaps = 4, scale=0.25, shift={-8,-8}},
+        light_oil_icon,
       },
       ingredients = {
         {type="fluid", name="light-oil", amount=20}


### PR DESCRIPTION
This PR changes the light oil overlay on the phenol recipe icon if played with K2.

Before

|with K2|without K2|
|-|-|
|<img width="39" alt="phenol-with-vanilla-light-oil-overlay" src="https://github.com/brevven/bzgas/assets/10973/5455eb7e-5b35-41c5-8197-34a6194674dd">|<img width="39" alt="phenol-with-vanilla-light-oil-overlay" src="https://github.com/brevven/bzgas/assets/10973/5455eb7e-5b35-41c5-8197-34a6194674dd">|

After

|with K2|without K2|
|-|-|
|<img width="38" alt="phenol-with-k2-light-oil-overlay" src="https://github.com/brevven/bzgas/assets/10973/cf09ca56-be10-4de2-8a05-8f0c2e14ac4b">|<img width="39" alt="phenol-with-vanilla-light-oil-overlay" src="https://github.com/brevven/bzgas/assets/10973/5455eb7e-5b35-41c5-8197-34a6194674dd">|


