### PR TITLE
Do not replace intermodal container packing recipes

### DIFF
--- a/data-util.lua
+++ b/data-util.lua
@@ -1304,6 +1304,7 @@ function util.replace_ingredients_prior_to(tech, old, new, multiplier)
     if (recipe.enabled and recipe.enabled ~= 'false')
       and (not recipe.hidden or recipe.hidden == 'true') -- probably don't want to change hidden recipes
       and string.sub(recipe.name, 1, 3) ~= 'se-' -- have to exlude SE in general :(
+      and string.sub(recipe.name, 1, 3) ~= 'ic-' -- do not replace intermodal container packing recipes
     then
       -- log("BZZZ due to 'enabled' replacing " .. old .. " with " .. new .." in " .. recipe.name) -- Handy Debug :|
       util.replace_ingredient(recipe.name, old, new, multiplier, true)


### PR DESCRIPTION
See issue #11 

This fixes a compatibility issue with Intermodal Containers where the recipe for packing electronic circuits was replaced with copper cables

Unusually it seems that the Lead mod must also be enabled? I did not investigate further